### PR TITLE
Create users

### DIFF
--- a/src/main/resources/wfc/schemas/auth.yaml
+++ b/src/main/resources/wfc/schemas/auth.yaml
@@ -113,12 +113,46 @@ $defs:
       generators:
         description: "List of generators for unique/random names to use in payload template resolution."
         type: array
+        minLength: 1
         items:
-          @ref
-        TODO
+          $ref: "#/$defs/Generator"
     x-required:
-      allOf: ["verb","contentType","payloadRaw"]
+      allOf: ["verb","contentType","payloadRaw","generators"]
       oneOf: ["endpoint","externalEndpointURL"]
+
+  Generator:
+    description: "Parametric producer of unique string values. \
+                  This is needed for example when creating user-names dynamically in the authentication configurations."
+    type: object
+    properties:
+      placeHolder:
+        description: "Placeholder tag used to represent a value generated with this generator. \
+                      String interpolation will be applied to the raw payloads to replace any found instance of \
+                      this placeholder with the generated value."
+        type: string
+        examples:
+        - "{$username}"
+        - "{$email}"
+      minLength:
+        description: "Minimum length of the generated string"
+        type: number
+        min: 0
+      maxLength:
+        description: "Maximum length of the generated string"
+        type: number
+        min: 0
+      prefix:
+        description: "Fixed prefix shared by all generated strings"
+        type: string
+        examples:
+        - "user_"
+      postfix:
+        description: "Fixed postfix shared by all generated strings"
+        type: string
+        examples:
+          - "@example.com"
+    x-required: ["placeHolder"]
+
   LoginEndpoint:
     description: "Used to represent the case in which a login endpoint is used to obtain the authentication credentials. \
                       These can be cookies, or a token extracted from the login endpoint's response. \

--- a/src/main/resources/wfc/schemas/auth.yaml
+++ b/src/main/resources/wfc/schemas/auth.yaml
@@ -130,6 +130,7 @@ $defs:
                       String interpolation will be applied to the raw payloads to replace any found instance of \
                       this placeholder with the generated value."
         type: string
+        minLength: 1
         examples:
         - "{$username}"
         - "{$email}"

--- a/src/main/resources/wfc/schemas/auth.yaml
+++ b/src/main/resources/wfc/schemas/auth.yaml
@@ -136,11 +136,11 @@ $defs:
         - "{$email}"
       minLength:
         description: "Minimum length of the generated string"
-        type: number
+        type: integer
         min: 0
       maxLength:
         description: "Maximum length of the generated string"
-        type: number
+        type: integer
         min: 0
       prefix:
         description: "Fixed prefix shared by all generated strings"

--- a/src/main/resources/wfc/schemas/auth.yaml
+++ b/src/main/resources/wfc/schemas/auth.yaml
@@ -81,8 +81,44 @@ $defs:
           $ref: "#/$defs/Header"
       loginEndpointAuth:
           $ref: "#/$defs/LoginEndpoint"
+      createUsers:
+          $ref: "#/$defs/CreateUsers"
     x-required: ["name"]
   ###
+  CreateUsers:
+    description: "For some example APIs, it might be possible to create new users with a single HTTP request. \
+                      In these cases, instead of relying on knowledge of existing users, the fuzzer can create them on \
+                      the fly. This can be useful when endpoints might modify data of existing users, whose auth info \
+                      could get invalidated during the fuzzing session."
+    type: object
+    properties:
+      endpoint:
+        description: "The endpoint path (eg '/users') where to execute the create user action. \
+                      It assumes it is on same server of API.\
+                      If not, rather use 'externalEndpointURL'."
+        type: string
+      externalEndpointURL:
+        description: "If the create endpoint is on a different server, here can rather specify the full URL for it."
+        type: string
+      payloadRaw:
+        description: "The raw payload to send, as a string. This will need to contain the template placeholders \
+                      defined in the generators. "
+        type: string
+      verb:
+        $ref: "#/$defs/HttpVerb"
+      contentType:
+        description: "Specify the format in which the payload is sent to the login endpoint. \
+                      A common example is 'application/json'."
+        type: string
+      generators:
+        description: "List of generators for unique/random names to use in payload template resolution."
+        type: array
+        items:
+          @ref
+        TODO
+    x-required:
+      allOf: ["verb","contentType","payloadRaw"]
+      oneOf: ["endpoint","externalEndpointURL"]
   LoginEndpoint:
     description: "Used to represent the case in which a login endpoint is used to obtain the authentication credentials. \
                       These can be cookies, or a token extracted from the login endpoint's response. \


### PR DESCRIPTION
Added `createUsers` option to specify how to create users on the fly, during fuzzing.
This is not really needed for real-world APIs, where usually user creation is handled in specialized, separated APIs (which then might require things such as email confirmations, solving CAPTCHAS, etc.), and there is no worries that calls to API can invalidate user credential (eg, change password).
But, it happens in few example APIs (especially regarding security, eg OWASP). 

Example of declaration:
```
auth:
  - name: "CreatedUser"
    createUsers:
      endpoint: "/api/authcreateusers/users"
      contentType: "application/json"
      verb: "POST"
      payloadRaw: '{"email": "{$username}@example.com", "password": "123456", "repeatPassword": "123456", "username": "{$username}"}'
      generators:
        - placeHolder: "{$username}"
          minLength: 8
          maxLength: 30
          prefix: "user_"
          postfix: ""
    loginEndpointAuth:
      endpoint: "/api/authcreateusers/users/login"
      verb: "POST"
      contentType: "application/json"
      payloadRaw: '{"email": "{$username}@example.com", "password": "123456"}'
      token:
        extractFrom: "body"
        extractSelector: "/token/authToken"
        sendIn: "header"
        sendName: "Authorization"
        sendTemplate: "Bearer {token}"
```

Implementation of `generators` to give unique names when re-executing tests is up to the fuzzer to decide. I have implemented a working prototype in EvoMaster, to see if feasible, and can create tests (in Python) like:

```
    # Calls:
    # (200) GET:/api/authcreateusers/check
    @timeout_decorator.timeout(60)
    def test_1_get_on_check_returns_content(self):
        
        generator_CreatedUser___username_ = create_string(8, 30, "user_", "")
        
        # Create new user dynamically for CreatedUser
        headers = {}
        headers["content-type"] = "application/json"
        body = (" { " + \
            " \"email\" : \"{$username}@example.com\", " + \
            " \"password\" : \"123456\", " + \
            " \"repeatPassword\" : \"123456\", " + \
            " \"username\" : \"{$username}\" " + \
            " } ").replace("{$username}", generator_CreatedUser___username_)
        res_create_user_CreatedUser = requests \
                .post(self.baseUrlOfSut + "/api/authcreateusers/users", 
                    headers=headers, data=body, allow_redirects=False, verify=False)
        assert res_create_user_CreatedUser.status_code >= 200 and res_create_user_CreatedUser.status_code < 400
        
        headers = {}
        headers["content-type"] = "application/json"
        body = (" { " + \
            " \"email\" : \"{$username}@example.com\", " + \
            " \"password\" : \"123456\" " + \
            " } ").replace("{$username}", generator_CreatedUser___username_)
        res_CreatedUser = requests \
                .post(self.baseUrlOfSut + "/api/authcreateusers/users/login", 
                    headers=headers, data=body, allow_redirects=False, verify=False)
        token_CreatedUser =  res_CreatedUser.json()["token"]["authToken"]
        
        auth_CreatedUser = "Bearer " + token_CreatedUser
        
        headers = {}
        headers["Authorization"] = auth_CreatedUser # CreatedUser
        headers['Accept'] = "*/*"
        res_0 = requests \
                .get(self.baseUrlOfSut + "/api/authcreateusers/check",
                    headers=headers, timeout=60, verify=False)
        
        assert res_0.status_code == 200
        assert "text/plain" in res_0.headers["content-type"]
        assert "OK" in res_0.text
```
